### PR TITLE
doc: update Git URL in README

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ order to work on older distributions (eg. Red Hat Enterprise Linux 6).
 
 To get the source, compile, and install:
 
-  git clone https://github.com/yehudasa/mod-proxy-fcgi
+  git clone https://github.com/ceph/mod-proxy-fcgi
   cd mod-proxy-fcgi
   autoconf
   ./configure


### PR DESCRIPTION
The mod-proxy-fcgi repository has moved to the "ceph" organization in GitHub. Update the README to reflect this.
